### PR TITLE
Fixed image name in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       timeout: 10s
       retries: 3
   helper:
-    image: devaslanphp/helper:latest
+    image: eloufirhatim/helper:latest
     container_name: helper-server
     environment:
       - DB_CONNECTION=mysql


### PR DESCRIPTION
The image name on Docker hub is not same as mentioned in the docker-compose.yml. Using the previous file failed when pulling the image from Docker hub.