### PR TITLE
fix / ProjectResource: can't save unique ticket_prefix

### DIFF
--- a/app/Filament/Resources/ProjectResource.php
+++ b/app/Filament/Resources/ProjectResource.php
@@ -77,7 +77,7 @@ class ProjectResource extends Resource
                                                     ->label(__('Ticket prefix'))
                                                     ->maxLength(3)
                                                     ->columnSpan(2)
-                                                    ->unique(Project::class, column: 'ticket_prefix')
+                                                    ->unique(ignoreRecord: true)
                                                     ->disabled(
                                                         fn($record) => $record && $record->tickets()->count() != 0
                                                     )


### PR DESCRIPTION
Related issue: #63 
Regression introduced by fix: #73 

When editing a Project, it cannot be saved, because validator doesn't exclude current model's value from the check. It can be fixed using `ignoreRecord: true`
```php
Forms\Components\TextInput::make('ticket_prefix')
  ...
  ->unique(ignoreRecord: true)
```
Documentation:
https://filamentphp.com/docs/2.x/forms/validation#unique

Filament Admin resolves the table and column based on resource model and field name, so manually inputting it is not necessary, unless the source of uniqueness really is somewhere else, so I removed it.

If you prefer verbosity, it can be reintroduced like this:
```php
Forms\Components\TextInput::make('ticket_prefix')
  ...
  ->unique(table: Project::class, column: 'ticket_prefix', ignoreRecord: true)
```