### PR TITLE
Fix: Corrected the entity owner by responsible.

### DIFF
--- a/app/Filament/Resources/TicketResource.php
+++ b/app/Filament/Resources/TicketResource.php
@@ -258,7 +258,7 @@ class TicketResource extends Resource
             Tables\Columns\TextColumn::make('responsible.name')
                 ->label(__('Responsible'))
                 ->sortable()
-                ->formatStateUsing(fn($record) => view('components.user-avatar', ['user' => $record->owner]))
+                ->formatStateUsing(fn($record) => view('components.user-avatar', ['user' => $record->responsible]))
                 ->searchable(),
 
             Tables\Columns\TextColumn::make('status.name')


### PR DESCRIPTION
Corrected the entity owner by responsible in the responsible fragment of the ticket resource.

This is so that the ticket listing correctly shows the responsible person in the responsible column and not the owner.

![image](https://github.com/devaslanphp/project-management/assets/39111029/f593176d-4aae-482a-8e47-a7040dbef95a)
