### PR TITLE
Improvement: Role resource updates

### DIFF
--- a/app/Filament/Resources/RoleResource.php
+++ b/app/Filament/Resources/RoleResource.php
@@ -45,7 +45,7 @@ class RoleResource extends Resource
                             ->columns(1)
                             ->schema([
                                 Forms\Components\TextInput::make('name')
-                                    ->label(__('Permission name'))
+                                    ->label(__('Role name'))
                                     ->unique(table: Permission::class, column: 'name')
                                     ->maxLength(255)
                                     ->required(),
@@ -65,7 +65,7 @@ class RoleResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('name')
-                    ->label(__('Permission name'))
+                    ->label(__('Role'))
                     ->sortable()
                     ->searchable(),
 

--- a/app/Filament/Resources/TicketTypeResource/Pages/EditTicketType.php
+++ b/app/Filament/Resources/TicketTypeResource/Pages/EditTicketType.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Resources\TicketTypeResource\Pages;
 
 use App\Filament\Resources\TicketTypeResource;
-use App\Models\TicketStatus;
+use App\Models\TicketType;
 use Filament\Pages\Actions;
 use Filament\Resources\Pages\EditRecord;
 
@@ -22,7 +22,7 @@ class EditTicketType extends EditRecord
     protected function afterSave(): void
     {
         if ($this->record->is_default) {
-            TicketStatus::where('id', '<>', $this->record->id)
+            TicketType::where('id', '<>', $this->record->id)
                 ->where('is_default', true)
                 ->update(['is_default' => false]);
         }

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -62,7 +62,7 @@ class UserResource extends Resource
                                     ->maxLength(255),
 
                                 Forms\Components\CheckboxList::make('roles')
-                                    ->label(__('Permission roles'))
+                                    ->label(__('Roles'))
                                     ->required()
                                     ->columns(3)
                                     ->relationship('roles', 'name'),


### PR DESCRIPTION
Improvement: Renamed Permission to Role in some places. `__('Role name')` must be added to translations