### PR TITLE
Improvement: Make TicketStatus orderable

### DIFF
--- a/app/Filament/Resources/TicketStatusResource.php
+++ b/app/Filament/Resources/TicketStatusResource.php
@@ -107,6 +107,7 @@ class TicketStatusResource extends Resource
             ->bulkActions([
                 Tables\Actions\DeleteBulkAction::make(),
             ])
+            ->reorderable('order')
             ->defaultSort('order');
     }
 


### PR DESCRIPTION
By doing this, TicketStatuses can be sorted by drag and drop
![image](https://github.com/devaslanphp/project-management/assets/24251235/2aac71c8-aea9-4b7c-8978-31e3543d54c5)

![image](https://github.com/devaslanphp/project-management/assets/24251235/edc43940-f249-448d-9415-da2e6bde2365)
